### PR TITLE
fix(plugin) Kong now requires an exact error message 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root                     = true
+
+[*]
+end_of_line              = lf
+insert_final_newline     = true
+trim_trailing_whitespace = true
+charset                  = utf-8
+
+[*.lua]
+indent_style             = space
+indent_size              = 2
+
+[kong/templates/nginx*]
+indent_style             = space
+indent_size              = 4
+
+[*.template]
+indent_style             = space
+indent_size              = 4
+
+[Makefile]
+indent_style             = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.rock
 .DS_Store
+servroot

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,45 @@
+-- Configuration file for LuaCheck
+-- see: https://luacheck.readthedocs.io/en/stable/
+--
+-- To run do: `luacheck .` from the repo
+
+std             = "ngx_lua"
+unused_args     = false
+redefined       = false
+max_line_length = false
+
+
+globals = {
+    "_KONG",
+    "kong",
+    "ngx.IS_CLI",
+}
+
+
+not_globals = {
+    "string.len",
+    "table.getn",
+}
+
+
+ignore = {
+    "6.", -- ignore whitespace warnings
+}
+
+
+include_files = {
+    "**/*.lua",
+    "*.rockspec",
+    ".busted",
+    ".luacheckrc",
+}
+
+exclude_files = {
+    --"spec/fixtures/invalid-module.lua",
+    --"spec-old-api/fixtures/invalid-module.lua",
+}
+
+
+files["spec/**/*.lua"] = {
+    std = "ngx_lua+busted",
+}

--- a/create.sh
+++ b/create.sh
@@ -55,11 +55,12 @@ rm ./template/plugin/*.rockspec > /dev/null 2>&1
 
 docker run \
     --rm \
+    --user root \
     --volume "$PWD/template:/template" \
     --workdir="/template/plugin" \
     -e KONG_PRIORITY_NAME="$PLUGINNAME" \
     -e KONG_PRIORITY="$PRIORITY" \
-    kong:1.1.2 \
+    kong:2.1.4 \
     /usr/local/openresty/luajit/bin/luajit ../priority.lua
 
 mv ./template/plugin/*.rock ./ > /dev/null 2>&1

--- a/create.sh
+++ b/create.sh
@@ -7,7 +7,7 @@ if [ "$1" == "--help" ]; then
   echo "but with the new priority."
   echo
   echo "Usage:"
-  echo "    $BASH_SOURCE \"PLUGIN_NAME\" \"NEW_PRIORITY\""
+  echo "    ${BASH_SOURCE[0]} \"PLUGIN_NAME\" \"NEW_PRIORITY\""
   echo
   echo "    PLUGIN_NAME  : name of existing plugin to re-prioritize"
   echo "    NEW_PRIORITY : the priority the new plugin should have"
@@ -16,7 +16,7 @@ if [ "$1" == "--help" ]; then
   echo "This new name is mandatory and cannot be changed."
   echo
   echo "Example:"
-  echo "    $BASH_SOURCE \"request-termination\" \"15\""
+  echo "    ${BASH_SOURCE[0]} \"request-termination\" \"15\""
   echo
   echo "Will create:"
   echo "    kong-plugin-request-termination_15-0.1-1.rock"
@@ -24,7 +24,7 @@ if [ "$1" == "--help" ]; then
   echo "It can be installed using:"
   echo "    luarocks install kong-plugin-request-termination_15-0.1-1.rock"
   echo
-  
+
   exit 0
 fi
 
@@ -33,12 +33,12 @@ PRIORITY="$2"
 
 if [ "$PLUGINNAME" == "" ]; then
   echo "Missing plugin name, rerun with '--help' for info."
-  
+
   exit 1
 fi
 
 if [ "$PRIORITY" == "" ]; then
-  echo "Missing plugin priority, rerun with '--help' for info."  
+  echo "Missing plugin priority, rerun with '--help' for info."
   exit 1
 fi
 
@@ -55,7 +55,7 @@ rm ./template/plugin/*.rockspec > /dev/null 2>&1
 
 docker run \
     --rm \
-    --volume $PWD/template:/template \
+    --volume "$PWD/template:/template" \
     --workdir="/template/plugin" \
     -e KONG_PRIORITY_NAME="$PLUGINNAME" \
     -e KONG_PRIORITY="$PRIORITY" \

--- a/template/plugin/api.lua
+++ b/template/plugin/api.lua
@@ -1,5 +1,6 @@
 -- capture original plugin name, and new priority from filename
-local plugin_name, priority = ({...})[1]:match("^kong%.plugins%.([^%.]-)_(%d+)%.api$")
+local this_module_name = ({...})[1]
+local plugin_name, priority = this_module_name:match("^kong%.plugins%.([^%.]-)_(%d+)%.api$")
 if not plugin_name or not priority then
   error("Plugin file must be named '..../kong/plugins/<name>_<priority>/api.lua', got: " .. tostring(({...})[1]))
 end
@@ -8,7 +9,8 @@ local module_name = "kong.plugins." .. plugin_name .. ".api"
 
 if package.loaded[module_name] then
   -- the api file should be loaded only once, so error out as if the module wasn't found
-  return error("original was already loaded")
+  -- error must match exactly, since the loader validates it
+  return error("module '" .. this_module_name .. "' not found")
 end
 
 -- if this fails, it is identical to the original failing, so the error indicates it's not there

--- a/template/plugin/daos.lua
+++ b/template/plugin/daos.lua
@@ -1,5 +1,6 @@
 -- capture original plugin name, and new priority from filename
-local plugin_name, priority = ({...})[1]:match("^kong%.plugins%.([^%.]-)_(%d+)%.daos$")
+local this_module_name = ({...})[1]
+local plugin_name, priority = this_module_name:match("^kong%.plugins%.([^%.]-)_(%d+)%.daos$")
 if not plugin_name or not priority then
   error("Plugin file must be named '..../kong/plugins/<name>_<priority>/daos.lua', got: " .. tostring(({...})[1]))
 end
@@ -7,9 +8,9 @@ end
 local module_name = "kong.plugins." .. plugin_name .. ".daos"
 
 if package.loaded[module_name] then
-  -- the daos file should be loaded only once, and was already loaded,
-  -- so error out as if the module wasn't found
-  return error("original was already loaded")
+  -- the daos file should be loaded only once, so error out as if the module wasn't found
+  -- error must match exactly, since the loader validates it
+  return error("module '" .. this_module_name .. "' not found")
 end
 
 -- if this fails because it doesn't exist, it is identical to the original


### PR DESCRIPTION
Previously any error would be good enough to load. With recent
versions of Kong the `daos.lua` and `api.lua` file need to throw
an exact error for this to work.

The fix was only needed if the original plugin had either of those
2 files.